### PR TITLE
restart triton during setup if it crashes or doesn't start within 3 minutes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,8 @@ COPY tensorrtllm_backend /src/tensorrtllm_backend
 # pip install requirements and prerelease cog
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install https://r2.drysys.workers.dev/tmp/cog-0.9.4.dev81+g11986a1-py3-none-any.whl -r /tmp/requirements.txt 
-COPY *.py *.yaml /src/
-COPY triton_model_repo /src/triton_model_repo
-COPY triton_templates /src/triton_templates
-
 # prevent replicate from downgrading cog
 RUN ln -sf $(which echo) $(which pip)
-COPY ./cog.yaml ./sse.py ./predict.py ./utils.py /src/
+COPY triton_model_repo /src/triton_model_repo
+COPY triton_templates /src/triton_templates
+COPY *.py *.yaml /src/

--- a/launch_triton_server.py
+++ b/launch_triton_server.py
@@ -1,0 +1,121 @@
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--world_size",
+        type=int,
+        default=1,
+        help="world size, only support tensor parallelism now",
+    )
+    parser.add_argument(
+        "--tritonserver",
+        type=str,
+        help="path to the tritonserver exe",
+        default="/opt/tritonserver/bin/tritonserver",
+    )
+    parser.add_argument(
+        "--grpc_port",
+        type=str,
+        help="tritonserver grpc port",
+        default="8001",
+    )
+    parser.add_argument(
+        "--http_port",
+        type=str,
+        help="tritonserver http port",
+        default="8000",
+    )
+    parser.add_argument(
+        "--metrics_port",
+        type=str,
+        help="tritonserver metrics port",
+        default="8002",
+    )
+    parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="launch tritonserver regardless of other instances running",
+    )
+    parser.add_argument(
+        "--log", action="store_true", help="log triton server stats into log_file"
+    )
+    parser.add_argument(
+        "--log-file",
+        type=str,
+        help="path to triton log gile",
+        default="triton_log.txt",
+    )
+
+    path = str(Path(__file__).parent.absolute()) + "/../all_models/gpt"
+    parser.add_argument("--model_repo", type=str, default=path)
+    return parser.parse_args()
+
+
+def get_cmd(
+    world_size,
+    tritonserver,
+    grpc_port,
+    http_port,
+    metrics_port,
+    model_repo,
+    log,
+    log_file,
+):
+    if os.getenv("NO_PROFILE"):
+        cmd = ["mpirun", "--allow-run-as-root"]
+    else:
+        cmd = ["nsys", "profile", "--wait=primary", "mpirun", "--allow-run-as-root"]
+    for i in range(world_size):
+        cmd += ["-n", "1", tritonserver]
+        if log and (i == 0):
+            cmd += ["--log-verbose=3", f"--log-file={log_file}"]
+        cmd += [
+            f"--grpc-port={grpc_port}",
+            f"--http-port={http_port}",
+            f"--metrics-port={metrics_port}",
+            f"--model-repository={model_repo}",
+            "--disable-auto-complete-config",
+            f"--backend-config=python,shm-region-prefix-name=prefix{i}_",
+            ":",
+        ]
+    return cmd
+
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    res = subprocess.run(
+        ["pgrep", "-r", "R", "tritonserver"], capture_output=True, encoding="utf-8"
+    )
+    if res.stdout:
+        pids = res.stdout.replace("\n", " ").rstrip()
+        msg = f"tritonserver process(es) already found with PID(s): {pids}.\n\tUse `kill {pids}` to stop them."
+        if args.force:
+            print(msg, file=sys.stderr)
+        else:
+            raise RuntimeError(msg + " Or use --force.")
+    cmd = get_cmd(
+        int(args.world_size),
+        args.tritonserver,
+        args.grpc_port,
+        args.http_port,
+        args.metrics_port,
+        args.model_repo,
+        args.log,
+        args.log_file,
+    )
+
+    environ = os.environ.copy()
+    # previously, this used Popen and exited with an orphaned subprocess
+    # this prevents us from checking if triton has exited, so we want exec instead
+    # exec: replace the current process with mpirun
+    # v: variable number of arguments
+    # p: use PATH to locate the executable
+    # e: use an environ
+    os.execvpe(cmd[0], cmd, environ)

--- a/predict.py
+++ b/predict.py
@@ -18,8 +18,7 @@ from utils import (
 
 
 class Predictor(BasePredictor):
-    def setup(self, weights: str = None) -> None:
-
+    async def setup(self, weights: str = "") -> None:
         COG_TRITON_CONFIG = os.getenv("COG_TRITON_CONFIG", "config.yaml")
         if not os.path.exists(COG_TRITON_CONFIG):
             print(f"Config file {COG_TRITON_CONFIG} not found. Defaults will be used.")
@@ -53,41 +52,49 @@ class Predictor(BasePredictor):
             print("Engine directory is empty. Exiting.")
             self.model_exists = False
             return
-
         self.model_exists = True
-        world_size = os.getenv("WORLD_SIZE", "1")
+        self.client = httpx.AsyncClient(timeout=10)
+        for i in range(3):
+            if start_triton():
+                return
+        raise Exception(f"Couldn't start Triton (exit code {self.proc.poll()})")
+
+    async def start_triton(self) -> None:
         # # launch triton server
         # # python3 scripts/launch_triton_server.py --world_size=1 --model_repo=/src/tensorrtllm_backend/triton_model
-        subprocess.run(
+        world_size = os.getenv("WORLD_SIZE", "1")
+        self.proc = subprocess.run(
             [
                 "python3",
-                "/src/tensorrtllm_backend/scripts/launch_triton_server.py",
+                "/src/launch_triton_server.py",
                 f"--world_size={world_size}",
                 "--log",
                 "--model_repo=/src/triton_model_repo",
             ]
         )
-        # Health check Triton until it is ready
-        while True:
+        # Health check Triton until it is ready or for 3 minutes
+        for i in range(180):
             try:
-                response = httpx.get("http://localhost:8000/v2/health/ready")
+                response = await self.client.get(
+                    "http://localhost:8000/v2/health/ready"
+                )
                 if response.status_code == 200:
                     print("Triton is ready.")
-                    break
+                    return True
             except httpx.RequestError:
                 pass
-            time.sleep(1)
-
-        self.client = httpx.AsyncClient(timeout=10)
+            await asyncio.sleep(1)
+        self.proc.terminate()
+        await asyncio.sleep(0.001)
+        self.proc.kill()
+        return False
 
     async def predict(
         self,
-        prompt: str = Input(
-            description="Prompt to send to the model."
-            ),
+        prompt: str = Input(description="Prompt to send to the model."),
         system_prompt: str = Input(
             description="System prompt to send to the model. This is prepended to the prompt and helps guide system behavior.",
-            default= os.getenv("SYSTEM_PROMPT", "")
+            default=os.getenv("SYSTEM_PROMPT", ""),
         ),
         max_new_tokens: int = Input(
             description="Maximum number of tokens to generate. A word is generally 2-3 tokens",
@@ -200,7 +207,9 @@ class Predictor(BasePredictor):
                 yield current_output
 
         self.log(f"Random seed used: `{args['random_seed']}`\n")
-        self.log("Note: Random seed will not impact output if greedy decoding is used.\n")
+        self.log(
+            "Note: Random seed will not impact output if greedy decoding is used.\n"
+        )
         self.log(f"Formatted prompt: `{formatted_prompt}`")
 
     def _process_args(


### PR DESCRIPTION
sporadically, triton will segfault during startup. because launch_triton_server.py uses Popen and exits, leaving mpirun as an orphan, our setup will just keep waiting for triton to come up forever and not even restart. if just running triton again can fix it and we can avoid re-downloading the weights, that's a win, but if not, we should still exit promptly instead of hitting the (very long) setup timeout for replicate-internal/replicate. however, if we figure out what's causing this actually fixing that would obviously be better than patching over it.

```
*** Process received signal ***
Signal: Segmentation fault (11)
Signal code: Address not mapped (1)
Failing at address: 0xb0
```

https://replicatehq.slack.com/archives/C0617RF4HHP/p1710458336169009?thread_ts=1710458110.755169&cid=C0617RF4HHP