### PR TITLE
Unify cog-triton Dockerfile LANG-213

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,22 @@
 #syntax=docker/dockerfile:1.4
-FROM triton_trt_llm as deps
+# Use the CUDA 12.1.0 devel base image
+FROM nvcr.io/nvidia/tritonserver:24.03-py3
+
+# Install required dependencies
+RUN apt-get update && apt-get -y install \
+    python3.10 \
+    python3-pip \
+    openmpi-bin \
+    libopenmpi-dev
+
+# Install the latest preview version of TensorRT-LLM
+# RUN pip3 install tensorrt_llm -U --pre --extra-index-url https://pypi.nvidia.com
+
+# Install the latest stable version (corresponding to the release branch) of TensorRT-LLM.
+RUN pip3 install tensorrt_llm==0.8.0 --extra-index-url https://pypi.nvidia.com
+
+RUN ln -sf /usr/bin/python3 /usr/bin/python
+
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ cp -r ../cog-trt-llm/engine_outputs/* triton_model_repo/tensorrt_llm/1/
 Run the cog-triton image:
 
 ```
-docker run --rm -it -p 5000:5000 --gpus=all --workdir /src  --net=host --volume $(pwd)/.:/src/. --ulimit memlock=-1 --shm-size=20g cog-triton /bin/bash
+docker run --rm -it -p 5000:5000 --gpus=all --workdir /src --volume $(pwd)/.:/src/. --ulimit memlock=-1 --shm-size=20g cog-triton /bin/bash
 python -m cog.server.http
 ```
 
@@ -135,7 +135,7 @@ time python3 scripts/test_perf.py --target cog-triton --rate 8 --unit rps --dura
 
 Cog-triton is pre-release and not stable. This build process is not optimal and will change. However, here we document every step we took to generate a deployable cog-triton image.
 
-1. Clone the cog-triton image:
+1. Clone the cog-triton repo:
 
 ```
 git clone https://github.com/replicate/cog-triton 
@@ -151,15 +151,7 @@ git submodule update --init --recursive
 cd ..
 ```
 
-3. Build TensorRT-LLM Backend
-
-```
-# Use the Dockerfile to build the backend in a container
-# For x86_64
-DOCKER_BUILDKIT=1 docker build -t triton_trt_llm -f ./dockerfile/Dockerfile.trt_llm_backend .
-```
-
-4. Build cog-triton
+3. Build cog-triton image
 
 ```
 cd ..
@@ -256,3 +248,25 @@ curl -s -X POST \
 curl -X POST localhost:8000/v2/models/ensemble/generate -d '{"text_input": "What is machine learning?", "max_tokens": 20, "bad_words": "", "stop_words": ""}'
 
 curl -X POST localhost:8000/v2/models/ensemble/generate -d '{"text_input": "Water + Fire = Steam\nEarth + Water = Plant\nHuman + Robe = Judge\nCow + Fire = Steak\nKing + Ocean = Poseidon\nComputer + Spy =", "max_tokens": 20, "bad_words": "", "stop_words": ""}'
+
+
+
+curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -d $'{
+    "input": {
+        "prompt": "Water + Fire = Steam\nEarth + Water = Plant\nHuman + Robe = Judge\nCow + Fire = Steak\nKing + Ocean = Poseidon\nComputer + Spy ="
+    }
+  }' \
+  http://localhost:5000/predictions
+
+  curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -d $'{
+    "input": {
+        "prompt": "Water + Fire = Steam\nEarth + Water = Plant\nHuman + Robe = Judge\nCow + Fire = Steak\nKing + Ocean = Poseidon\nComputer + Spy ="
+    }
+  }' \
+  http://localhost:5000/predictions
+
+  # Dev Install TRT-LLM with pip


### PR DESCRIPTION
Currently, we have an awful build process where the cog-triton Dockerfile uses a locally-built image as its base. The locally built image is produced via the tensorrtllm_backend image build process. This is bad because it is slow and it has repeatedly hindered reproducibility and collaboration. 

Now that trt-llm can be pip installed and NVIDIA is publishing nightlies, we should unify the cog-triton Dockerfile so it uses a Triton base image and pip installs TensorRT-LLM.

This will make it easier for us to collaborate and it will make our builds and development process more reproducible. For these reasons, this is a high priority, as it should remove collaboration bottlenecks and hopefully help decrease the frequency of regressions.

This PR:

* Updates the cog-triton Dockerfile to use a tritonserver base
* pip installs TensorRT-LLM==0.8.0
* Aliases python3 to python to maintain backwards compatibility and presumably compatibility with cog