### PR TITLE
Joe/yorickvp/ci/joe/lang 220 identify cog triton tps bottleneck

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import httpx
 from cog import BasePredictor, ConcatenateIterator, Input
+import time
 
 from sse import receive_sse
 from triton_config_generator import generate_configs, load_yaml_config
@@ -19,9 +20,13 @@ from utils import (
     StreamingTokenStopSequenceHandler,
 )
 
+from transformers import AutoTokenizer
 
 class Predictor(BasePredictor):
     async def setup(self, weights: str = "") -> None:
+        self.log_performance_metrics = bool(os.getenv("LOG_PERFORMANCE_METRICS", False))
+
+        
         COG_TRITON_CONFIG = os.getenv("COG_TRITON_CONFIG", "config.yaml")
         if not os.path.exists(COG_TRITON_CONFIG):
             print(f"Config file {COG_TRITON_CONFIG} not found. Defaults will be used.")
@@ -38,6 +43,9 @@ class Predictor(BasePredictor):
         engine_dir = os.environ.get(
             "ENGINE_DIR", "/src/triton_model_repo/tensorrt_llm/1/"
         )
+        
+        self.tokenizer = AutoTokenizer.from_pretrained(engine_dir)
+
 
         self.system_prompt_exists = os.getenv("SYSTEM_PROMPT", None)
         self.end_id = os.getenv("END_ID", 2)
@@ -183,7 +191,7 @@ class Predictor(BasePredictor):
 
         req = self.client.stream(
             "POST",
-            "http://localhost:8000/v2/models/tensorrt_llm_bls/generate_stream",
+            "http://localhost:8000/v2/models/ensemble/generate_stream",
             json=args,
         )
 
@@ -193,14 +201,25 @@ class Predictor(BasePredictor):
             stop_sequences=args["stop_words"]
         )
 
+        start_time = time.time()
+        n_tokens = 0
+        tokens = np.array([], dtype=np.int32)
+
         async with req as resp:
             async for event in receive_sse(resp):
                 # Output is the _entire_ sequence, from the beginning
                 try:
-                    output = event.json()["text_output"]
+                    token = event.json()["output_ids"]
                 # this check can be removed once we identify the cause of KeyError
                 except Exception as e:
                     raise Exception(f"error with event {event}") from e
+                
+                n_tokens += 1
+                if n_tokens == 1:
+                    first_token_time = time.time()
+                
+                tokens = np.append(tokens, token)
+                output = self.tokenizer.decode(tokens, skip_special_tokens=True)
                 # Catches partial emojis, waits for them to finish
                 output = output.replace("\N{Replacement Character}", "")
                 # Remove the tokens that were already yielded
@@ -221,6 +240,22 @@ class Predictor(BasePredictor):
             current_output = stop_sequence_handler.finalize()
             if current_output:
                 yield current_output
+        
+        end_time = time.time()
+        if self.log_performance_metrics:
+            latency = end_time - start_time
+            actual_tps = n_tokens / latency
+            time_to_first_token = first_token_time - start_time
+            self.log(f"Tokens processed: {n_tokens}\n")
+            self.log(f"Serverside tokens per second: {round(actual_tps, 2)}\n")
+            self.log(f"Serverside execution time: {round(latency, 2)} seconds\n")
+            self.log(f"Serverside time to first token: {round(time_to_first_token, 2)} seconds\n")
+
+        self.log(f"Random seed used: `{args['random_seed']}`\n")
+        self.log(
+            "Note: Random seed will not impact output if greedy decoding is used.\n"
+        )
+        self.log(f"Formatted prompt: `{formatted_prompt}`")
 
         self.log(f"Random seed used: `{args['random_seed']}`\n")
         self.log(

--- a/scripts/test_perf.py
+++ b/scripts/test_perf.py
@@ -5,9 +5,14 @@ import argparse
 from datetime import datetime, timedelta
 import os
 import json
-
+import matplotlib.pyplot as plt
+import os
+from datetime import datetime
+import sys
 # Environment variable for Replicate API token
 REPLICATE_API_TOKEN = os.getenv("REPLICATE_API_TOKEN")
+
+from transformers import AutoTokenizer
 
 # Global counters and lists
 times = []
@@ -22,16 +27,23 @@ n_requests_started = 0
 n_requests_completed = 0
 n_cog_already_running_prediction = 0
 
+tokenizer = AutoTokenizer.from_pretrained("triton_model_repo/tensorrt_llm/1/")
+
+def count_output_tokens(text):
+    return len(tokenizer.tokenize(text))
 
 def format_request_data(n_input_tokens, n_output_tokens, target):
-    prompt = " a" * n_input_tokens
+    prompt = " a" *(n_input_tokens - 1)
+    prompt_ids = count_output_tokens(prompt)
+    assert n_input_tokens == prompt_ids, f"incorrect number of input tokens: {prompt_ids}. Expected: {n_input_tokens}"
+
 
     if target not in ["cog-triton", "triton"]:
         return {
             "version": target,
             "input": {
                 "prompt": prompt,
-                "min_length": n_output_tokens,
+                "min_new_tokens": n_output_tokens,
                 "max_new_tokens": n_output_tokens,
             },
         }
@@ -41,7 +53,7 @@ def format_request_data(n_input_tokens, n_output_tokens, target):
             "input": {
                 "prompt": prompt,
                 "max_new_tokens": n_output_tokens,
-                "min_length": n_output_tokens,
+                "min_new_tokens": n_output_tokens,
             }
         }
     elif target == "triton":
@@ -88,77 +100,96 @@ async def make_request(url, headers, data, target):
     start_times.append(start_time)
     # print(f"[REQUEST STARTED]: {start_time}")  # Log start time
 
-    try:
-        # Make the request
-        response = await client.post(url, headers=headers, json=data)
-        n_requests_made += 1
+    # try:
+    # Make the request
+    response = await client.post(url, headers=headers, json=data)
+    n_requests_made += 1
+    if target in ["cog-triton", "triton"]:
+        end_time = datetime.now()
+        returned_requests.append(response.text)
 
-        if target in ["cog-triton", "triton"]:
-            end_time = datetime.now()
-            returned_requests.append(response.text)
+    else:
+        response = await poll_replicate_request(response, headers)
+        completed_at = response["completed_at"]
+        end_time = parse_cog_time(completed_at)
+        returned_requests.append(response)
 
+    # Handle "Already running a prediction" from cog-triton
+    if target == "cog-triton":
+        if (
+            "Already running a prediction" in response.text
+            and response.status_code == 409
+        ):
+            n_cog_already_running_prediction += 1
+            return
+
+    # Handle "Already running a prediction" from production
+    elif target != "triton":
+        if (
+            "detail" in response
+            and "Already running a prediction" in response["detail"]
+        ):
+            n_cog_already_running_prediction += 1
+            return
+
+    # if we get here, the request was at least picked up by cog, if we're using cog
+    n_requests_started += 1
+
+    request_completed = False
+    if target == "triton":
+        if response.status_code != 200:
+            failures += 1
+        prefix = "data: "
+        json_str = response.text[len(prefix) :]
+        response = json.loads(json_str)
+
+        # If output is empty, count as failure
+        if not response["output_ids"]:
+            failures += 1
         else:
-            response = await poll_replicate_request(response, headers)
-            completed_at = response["completed_at"]
-            end_time = parse_cog_time(completed_at)
-            returned_requests.append(response)
+            n_requests_completed += 1
+            request_completed = True
 
-        # Handle "Already running a prediction" from cog-triton
+    else:
         if target == "cog-triton":
-            if (
-                "Already running a prediction" in response.text
-                and response.status_code == 409
-            ):
-                n_cog_already_running_prediction += 1
-                return
+            response = response.json()
+        # print(response)
+        if response["status"] == "failed":
+            failures += 1
+            # print(f"Request failed: {response['error']}")
+        elif response["status"] == "succeeded":
+            n_requests_completed += 1
+            request_completed = True
 
-        # Handle "Already running a prediction" from production
-        elif target != "triton":
-            if (
-                "detail" in response
-                and "Already running a prediction" in response["detail"]
-            ):
-                n_cog_already_running_prediction += 1
-                return
+    if request_completed:
 
-        # if we get here, the request was at least picked up by cog, if we're using cog
-        n_requests_started += 1
-
-        request_completed = False
-        if target == "triton":
-            if response.status_code != 200:
-                failures += 1
-            prefix = "data: "
-            json_str = response.text[len(prefix) :]
-            response = json.loads(json_str)
-
-            # If output is empty, count as failure
-            if not response["text_output"]:
-                failures += 1
-            else:
-                n_requests_completed += 1
-                request_completed = True
+        
+        if target == "cog-triton":
+            output = ''.join(response["output"])
+            n_input_tokens = data["input"]["max_new_tokens"]
+            max_tokens = data["input"]["max_new_tokens"]
+        elif target == "triton":
+            # Trito
+            input_text = data["text_input"]
+            output = response["output_ids"][len(input_text):]
+            n_input_tokens = data["min_length"]
+            max_tokens = data["max_tokens"]
 
         else:
-            if target == "cog-triton":
-                response = response.json()
-            # print(response)
-            if response["status"] == "failed":
-                failures += 1
-                # print(f"Request failed: {response['error']}")
-            elif response["status"] == "succeeded":
-                n_requests_completed += 1
-                request_completed = True
-
-        if request_completed:
-            delta = (end_time - start_time).total_seconds()
-            times.append(delta)
-            start_end_times.append((start_time, end_time))
-            if target != "triton":
-                max_tokens = data["input"]["max_new_tokens"]
-            else:
-                max_tokens = data["max_tokens"]
-            sstps.append(max_tokens / delta)
+            output = response["output"]
+            n_input_tokens = data["input"]["max_new_tokens"]
+            max_tokens = data["input"]["max_new_tokens"]
+        
+        # assert n_output_tokens == max_tokens, f"incorrect number of output tokens: {n_output_tokens}. Expected: {max_tokens}"
+        
+        delta = (end_time - start_time).total_seconds()
+        times.append(delta)
+        start_end_times.append((start_time, end_time))
+        if target != "triton":
+            max_tokens = data["input"]["max_new_tokens"]
+        else:
+            max_tokens = data["max_tokens"]
+        sstps.append(max_tokens / delta)
 
         # if target != "triton":
         #     completed_at = response["completed_at"]
@@ -167,10 +198,10 @@ async def make_request(url, headers, data, target):
         #         f"{response_id}: start time {start_time}, end time {end_time}, delta {delta}, completed_at {completed_at}"
         #     )
 
-    except Exception as e:
-        failures += 1
-        print(response)
-        print(f"Request failed: {e}")
+    # except Exception as e:
+    #     failures += 1
+    #     # print(response)
+    #     print(f"Request failed: {e}")
 
 
 async def perform_requests(rate, duration, url, headers, data, mode, target):
@@ -183,7 +214,7 @@ async def perform_requests(rate, duration, url, headers, data, mode, target):
                 for _ in range(rate)
             ]
             await asyncio.gather(*tasks)
-            await asyncio.sleep(1)  # Rate limit batches per second
+            await asyncio.sleep(.5)  # Rate limit batches per second
         elif mode == "rps":
             await asyncio.sleep(1 / rate)  # Sleep to maintain the rate
             tasks.append(asyncio.create_task(make_request(url, headers, data, target)))
@@ -232,53 +263,59 @@ def estimate_rps(start_times):
 
     return rates
 
+def plot_metrics_with_lines(x, y, x_label, y_label, title, file_name):
+    plt.figure(figsize=(10, 6))
+    
+    # Sort the x and y values based on x to connect them correctly
+    sorted_indices = sorted(range(len(x)), key=lambda i: x[i])
+    sorted_x = [x[i] for i in sorted_indices]
+    sorted_y = [y[i] for i in sorted_indices]
+    
+    # Plot points and connect them with a line
+    plt.scatter(sorted_x, sorted_y, alpha=0.5)  # Plot points
+    plt.plot(sorted_x, sorted_y, '-o', label='Data', color='blue')  # Connect points with line
+    
+    # Add a dotted line for the median
+    median_value = stats.median(y)
+    plt.axhline(y=median_value, color='r', linestyle='--', label=f'Median: {median_value:.3f}')
+    
+    # Add titles and labels
+    plt.title(title)
+    plt.xlabel(x_label)
+    plt.ylabel(y_label)
+    plt.legend()  # Show legend
+    
+    # Save and close
+    plt.savefig(file_name)
+    plt.close()
 
-async def main():
-    parser = argparse.ArgumentParser(
-        description="Benchmark script for Triton or Cog server."
-    )
-    parser.add_argument(
-        "--target",
-        required=True,
-        help="Target server for the benchmark.",
-    )
-    parser.add_argument(
-        "--rate",
-        type=float,
-        required=True,
-        help="Number of requests per second (for rps) or total concurrent requests (for batch).",
-    )
-    parser.add_argument(
-        "--unit",
-        type=str,
-        choices=["rps", "batch"],
-        required=True,
-        help="Mode of operation: rps for requests per second, batch for concurrent requests.",
-    )
-    parser.add_argument(
-        "--duration", type=int, required=True, help="Duration of test in seconds."
-    )
-    parser.add_argument(
-        "--n_input_tokens", type=int, required=True, help="Number of input tokens."
-    )
-    parser.add_argument(
-        "--n_output_tokens", type=int, required=True, help="Number of output tokens."
-    )
-    parser.add_argument(
-        "--output_file",
-        default="returned_requests.txt",
-        type=str,
-        required=False,
-        help="Output file for failed responses.",
-    )
+def create_run_dir(args):
+    base_dir = "perf-results"
+    os.makedirs(base_dir, exist_ok=True)
 
-    args = parser.parse_args()
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    unique_dir_name = f"{timestamp}-{args.target}-{args.unit}-{int(args.rate)}-{args.duration}-{args.n_input_tokens}-{args.n_output_tokens}"
+    run_dir = os.path.join(base_dir, unique_dir_name)
+    os.makedirs(run_dir)
 
-    url = (
-        "http://localhost:8000/v2/models/tensorrt_llm_bls/generate_stream"
-        if args.target == "triton"
-        else "http://localhost:5000/predictions"
-    )
+    return run_dir
+
+
+class DualOutput:
+    def __init__(self, filePath):
+        self.terminal = sys.stdout
+        self.log = open(filePath, "a")
+
+    def write(self, message):
+        self.terminal.write(message)
+        self.log.write(message)
+
+    def flush(self):  # needed for Python 3 compatibility
+        pass
+
+async def main(run_dir, args):
+
+    sys.stdout = DualOutput(os.path.join(run_dir, "output.txt"))
 
     if args.target not in ["cog-triton", "triton"]:
         headers = {
@@ -290,7 +327,7 @@ async def main():
     else:
         headers = {"Content-Type": "application/json"}
         url = (
-            "http://localhost:8000/v2/models/tensorrt_llm_bls/generate_stream"
+            "http://localhost:8000/v2/models/ensemble/generate_stream"
             if args.target == "triton"
             else "http://localhost:5000/predictions"
         )
@@ -341,9 +378,19 @@ async def main():
     print("Response times (seconds):")
     print("---" * 10)
     if sstps:
-        print(f"Average single-stream TPS: {stats.mean(sstps):.3f}")
+        print("Single-stream TPS:")
+        if len(sstps) > 1:
+            print(f"SSTPS - Std: {stats.stdev(sstps):.3f}")
+        print(f"SSTPS - Median: {stats.median(sstps):.3f}")
+        print(f"SSTPS - Mean: {stats.mean(sstps):.3f}")
+        print(f"SSTPS - Max: {max(sstps):.3f}")
+        print(f"SSTPS - Min: {min(sstps):.3f}")
+        print("---" * 10)
+
     print("Median response latency:", round(stats.median(times), 3), "seconds")
     print("Mean response latency:", round(stats.mean(times), 3), "seconds")
+    if len(times) > 1:
+        print(f"Response Latency - Std: {stats.stdev(times):.3f} seconds")
     print("Max response latency:", round(max(times), 3), "seconds")
     print("Min response latency:", round(min(times), 3), "seconds")
     failure_rate = failures / n_requests_started if n_requests_started > 0 else 0
@@ -361,11 +408,28 @@ async def main():
     if "cog" in args.target:
         print(f"Cog already running prediction: {n_cog_already_running_prediction}")
     print(f"E2E throughput: {n_requests_completed / elapsed.total_seconds():.3f} rps")
+    
+    
+    output_file_path = os.path.join(run_dir, "returned_requests.json")
 
-    with open(args.output_file, "w") as f:
+    with open(output_file_path, "w") as f:
         for request in returned_requests:
             f.write(json.dumps(request))
             f.write("\n")
+
+    plot_file_path_tps = os.path.join(run_dir, 'tps_per_response_with_lines.png')
+    plot_metrics_with_lines(
+        range(len(sstps)), sstps,
+        'Response Number', 'Single-Stream TPS',
+        f'{args.target} Single-stream TPS per Response -- {args.unit}={args.rate}', plot_file_path_tps
+    )
+    
+    plot_file_path_latency = os.path.join(run_dir, 'latency_per_response_with_lines.png')
+    plot_metrics_with_lines(
+        range(len(times)), times,
+        'Response Number', 'Latency (seconds)',
+        f'{args.target} Latency per Response -- {args.unit}={args.rate}', plot_file_path_latency
+    )
 
     # print(
     #     f"Throughput: {stats.mean(sstps) * args.n_output_tokens:.3f} tokens per second"
@@ -373,4 +437,38 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    parser = argparse.ArgumentParser(description="Benchmark script for Triton or Cog server.")
+    parser.add_argument("--target", required=True, help="Target server for the benchmark.")
+    parser.add_argument("--rate", type=float, required=True, help="Number of requests per second (for rps) or total concurrent requests (for batch).")
+    parser.add_argument("--unit", type=str, choices=["rps", "batch"], required=True, help="Mode of operation: rps for requests per second, batch for concurrent requests.")
+    parser.add_argument("--duration", type=int, required=True, help="Duration of test in seconds.")
+    parser.add_argument("--n_input_tokens", type=int, required=True, help="Number of input tokens.")
+    parser.add_argument("--n_output_tokens", type=int, required=True, help="Number of output tokens.")
+    args = parser.parse_args()
+
+    base_dir = "perf-results"
+    os.makedirs(base_dir, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    unique_dir_name = f"{timestamp}-{args.target}-{args.unit}-{int(args.rate)}-{args.duration}-{args.n_input_tokens}-{args.n_output_tokens}"
+    run_dir = os.path.join(base_dir, unique_dir_name)
+    os.makedirs(run_dir, exist_ok=True)
+    sys.stdout = DualOutput(os.path.join(run_dir, "output.txt"))
+    asyncio.run(main(run_dir, args))
+
+
+    # plot_file_path_tps = os.path.join(run_dir, 'tps_per_response_with_lines.png')
+    # plot_metrics_with_lines(
+    #     range(len(sstps)), sstps,
+    #     x_label='Response Number',
+    #     y_label='Single-Stream TPS',
+    #     title='TPS per Response',
+    #     file_path=plot_file_path_tps
+    # )
+
+    # # Similarly, adjust other file output operations within `main`
+    # with open(os.path.join(run_dir, "output.txt"), "w") as f:
+    #     f.write("Your output here")
+
+    # # And for saving the args for reproducibility
+    # with open(os.path.join(run_dir, "args.json"), "w") as args_file:
+    #     json.dump(vars(args), args_file, indent=4)

--- a/triton_model_repo/ensemble/config.pbtxt
+++ b/triton_model_repo/ensemble/config.pbtxt
@@ -173,8 +173,8 @@ input [
 ]
 output [
   {
-    name: "text_output"
-    data_type: TYPE_STRING
+    name: "output_ids"
+    data_type: TYPE_INT32
     dims: [ -1 ]
   },
   {
@@ -421,7 +421,7 @@ ensemble_scheduling {
       }
       output_map {
         key: "OUTPUT"
-        value: "text_output"
+        value: "output_ids"
       }
       output_map {
         key: "OUT_OUTPUT_LOG_PROBS"

--- a/triton_model_repo/postprocessing/config.pbtxt
+++ b/triton_model_repo/postprocessing/config.pbtxt
@@ -64,7 +64,7 @@ input [
 output [
   {
     name: "OUTPUT"
-    data_type: TYPE_STRING
+    data_type: TYPE_INT32
     dims: [ -1 ]
   },
   {

--- a/triton_model_repo/preprocessing/config.pbtxt
+++ b/triton_model_repo/preprocessing/config.pbtxt
@@ -128,7 +128,7 @@ parameters {
 parameters {
   key: "tokenizer_type"
   value: {
-    string_value: "auto"
+    string_value: "llama"
   }
 }
 

--- a/triton_model_repo/tensorrt_llm/config.pbtxt
+++ b/triton_model_repo/tensorrt_llm/config.pbtxt
@@ -317,13 +317,13 @@ parameters: {
 parameters: {
   key: "max_attention_window_size"
   value: {
-    string_value: "4096"
+    string_value: "2560"
   }
 }
 parameters: {
   key: "batch_scheduler_policy"
   value: {
-    string_value: "max_utilization"
+    string_value: "guaranteed_no_evict"
   }
 }
 parameters: {

--- a/triton_templates/ensemble/config.pbtxt
+++ b/triton_templates/ensemble/config.pbtxt
@@ -173,7 +173,7 @@ input [
 ]
 output [
   {
-    name: "text_output"
+    name: "output_ids"
     data_type: TYPE_STRING
     dims: [ -1 ]
   },
@@ -421,7 +421,7 @@ ensemble_scheduling {
       }
       output_map {
         key: "OUTPUT"
-        value: "text_output"
+        value: "output_ids"
       }
       output_map {
         key: "OUT_OUTPUT_LOG_PROBS"

--- a/triton_templates/ensemble/config.pbtxt
+++ b/triton_templates/ensemble/config.pbtxt
@@ -174,7 +174,7 @@ input [
 output [
   {
     name: "output_ids"
-    data_type: TYPE_STRING
+    data_type: TYPE_INT32
     dims: [ -1 ]
   },
   {

--- a/triton_templates/postprocessing/config.pbtxt
+++ b/triton_templates/postprocessing/config.pbtxt
@@ -64,7 +64,7 @@ input [
 output [
   {
     name: "OUTPUT"
-    data_type: TYPE_STRING
+    data_type: TYPE_INT32
     dims: [ -1 ]
   },
   {


### PR DESCRIPTION
This PR:

* Factors token accounting and decoding out of postprocessing/1/model.py into predict.py so that we can use the ensemble endpoint instead of BLS. This is the fix for the cog-triton performance regression.
* Adds a envar flag to predict.py, `LOG_PERFORMANCE_METRICS`. If True, then performance metrics will be logged from predict.py.
* Updates scripts/perf_test.py so that server-side metrics are reported if available (e.g. if `LOG_PERFORMANCE_METRICS==True`