### PR TITLE
Merge nvidia-*-cu12 python with nix's cudaPackages

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -74,9 +74,12 @@ in
     };
     # has some binaries that want cudart
     tritonclient.mkDerivation.postInstall = "rm -r $out/bin";
+    # replace libtritonserver-90a4cf82.so with libtritonserver.so
+    # so backends don't have to know about the hash
     nvidia-pytriton.mkDerivation.postInstall = ''
       pushd $out/${site}/nvidia_pytriton.libs
       ln -s libtritonserver-*.so libtritonserver.so
+      patchelf --replace-needed libtritonserver-*.so libtritonserver.so $out/${python3.sitePackages}/pytriton/tritonserver/bin/tritonserver
       popd
       pushd $out/${site}/pytriton/tritonserver
       mv python_backend_stubs/${python3.pythonVersion}/triton_python_backend_stub backends/python/

--- a/default.nix
+++ b/default.nix
@@ -91,6 +91,24 @@ in
         hash = "sha256-LWntNtgfPB9mvusmEVg8bxFzUlQAuIeeMytGOZcNdz4=";
       };
     };
+    nvidia-cublas-cu12.mkDerivation.postInstall = ''
+      pushd $out/${python3.sitePackages}/nvidia/cublas/lib
+      for f in ./*.so.12; do
+        chmod +w "$f"
+        rm $f
+        ln -s ${cudaPackages.libcublas.lib}/lib/$f ./$f
+      done
+      popd
+    '';
+    nvidia-cudnn-cu12.mkDerivation.postInstall = ''
+      pushd $out/${python3.sitePackages}/nvidia/cudnn/lib
+      for f in ./*.so.8; do
+        chmod +w "$f"
+        rm $f
+        ln -s ${cudaPackages.cudnn.lib}/lib/$f ./$f
+      done
+      popd
+    '';
   };
   # TODO: open-source, switch to fetchFromGitHub
   deps.cog-trt-llm = builtins.fetchGit {

--- a/default.nix
+++ b/default.nix
@@ -75,6 +75,9 @@ in
     # has some binaries that want cudart
     tritonclient.mkDerivation.postInstall = "rm -r $out/bin";
     nvidia-pytriton.mkDerivation.postInstall = ''
+      pushd $out/${site}/nvidia_pytriton.libs
+      ln -s libtritonserver-*.so libtritonserver.so
+      popd
       pushd $out/${site}/pytriton/tritonserver
       mv python_backend_stubs/${python3.pythonVersion}/triton_python_backend_stub backends/python/
       rm -r python_backend_stubs/

--- a/nix/tensorrt-llm.nix
+++ b/nix/tensorrt-llm.nix
@@ -39,10 +39,10 @@ stdenv.mkDerivation (o: {
     cmake
     ninja
     python3
+    cudaPackages.cuda_nvcc
   ];
   buildInputs =
     [
-      cudaPackages.cuda_nvcc
       cudaPackages.cudnn.lib
       cudaPackages.cudnn.dev
       cudaPackages.nccl
@@ -54,6 +54,9 @@ stdenv.mkDerivation (o: {
       cudaPackages.cuda_nvcc.dev
       cudaPackages.cuda_cccl
       cudaPackages.libcublas.lib
+      cudaPackages.libcublas.dev
+      cudaPackages.libcurand.dev
+      cudaPackages.cuda_profiler_api
     ])
     ++ (lib.optionals withPython [
       cudaPackages.cudatoolkit
@@ -101,10 +104,6 @@ stdenv.mkDerivation (o: {
     "-DTRT_LIB_DIR=${pythonDrvs.tensorrt-libs.public}/${python3.sitePackages}/tensorrt_libs"
     "-DTRT_INCLUDE_DIR=${tensorrt-src}/include"
     "-DCMAKE_CUDA_ARCHITECTURES=${builtins.concatStringsSep ";" architectures}"
-    # todo: merge include paths for cuda_cudart, cublas manually
-    # otherwise the build pulls in Qt
-    "-DCUDAToolkit_INCLUDE_DIR=${cudaPackages.cudatoolkit}/include"
-    #  "-DCUDAToolkit_INCLUDE_DIR=${cudaPackages.cuda_cudart}/include"
     # "-DFAST_BUILD=ON"
   ];
   postBuild = lib.optionalString withPython ''

--- a/nix/tensorrt-llm.nix
+++ b/nix/tensorrt-llm.nix
@@ -13,6 +13,7 @@
   pythonDrvs,
   pybind11-stubgen ? null,
   withPython ? true,
+  rsync,
 }:
 stdenv.mkDerivation (o: {
   pname = "tensorrt_llm";
@@ -127,8 +128,7 @@ stdenv.mkDerivation (o: {
   installPhase =
     ''
       mkdir -p $out
-      cp -r $src/cpp $out/
-      # rm -rf $out/cpp/tensorrt_llm/kernels
+      ${rsync}/bin/rsync -a --exclude "tensorrt_llm/kernels" $src/cpp $out/
       chmod -R u+w $out/cpp
       mkdir -p $out/cpp/build/tensorrt_llm/plugins
       pushd tensorrt_llm

--- a/nix/trtllm-backend.nix
+++ b/nix/trtllm-backend.nix
@@ -59,16 +59,16 @@ oldGccStdenv.mkDerivation rec {
     cmake
     ninja
     python3
+    cudaPackages.cuda_nvcc
   ];
   buildInputs = [
     rapidjson
     openmpi
 
-    # if this stops working, replace with cudaPackages.cudaToolkit
-    cudaPackages.cuda_nvcc
     cudaPackages.cuda_cudart
     cudaPackages.cuda_cccl
-    cudaPackages.libcublas
+    cudaPackages.libcublas.lib
+    cudaPackages.libcublas.dev
   ];
   sourceRoot = "source/inflight_batcher_llm";
   cmakeFlags = [
@@ -80,7 +80,6 @@ oldGccStdenv.mkDerivation rec {
     "-DTRT_LIB_DIR=${trt_lib_dir}"
     "-DTRT_INCLUDE_DIR=${tensorrt-src}/include"
     "-DTRTLLM_DIR=${tensorrt-llm}"
-    "-DCUDAToolkit_INCLUDE_DIR=${cudaPackages.cuda_cudart}/include"
   ];
   # buildInputs = [ tensorrt-llm ];
   postFixup = ''

--- a/nix/trtllm-backend.nix
+++ b/nix/trtllm-backend.nix
@@ -64,8 +64,13 @@ oldGccStdenv.mkDerivation rec {
   ];
   buildInputs = [
     rapidjson
-    cudaPackages.cudatoolkit
     openmpi
+
+    # if this stops working, replace with cudaPackages.cudaToolkit
+    cudaPackages.cuda_nvcc
+    cudaPackages.cuda_cudart
+    cudaPackages.cuda_cccl
+    cudaPackages.libcublas
   ];
   sourceRoot = "source/inflight_batcher_llm";
   cmakeFlags = [
@@ -77,13 +82,13 @@ oldGccStdenv.mkDerivation rec {
     "-DTRT_LIB_DIR=${trt_lib_dir}"
     "-DTRT_INCLUDE_DIR=${tensorrt-src}/include"
     "-DTRTLLM_DIR=${tensorrt-llm}"
+    "-DCUDAToolkit_INCLUDE_DIR=${cudaPackages.cuda_cudart}/include"
   ];
   # buildInputs = [ tensorrt-llm ];
-  # linking to stubs/libtritonserver.so is maybe a bit shady
-  # $out/lib/stubs
-  # todo fix that hash
   # todo I think tensorrt_llm.so itself should have the cudnn dep
   postFixup = ''
-    patchelf $out/backends/tensorrtllm/libtriton_tensorrtllm.so --add-rpath ${trt_lib_dir}:${tensorrt-llm}/cpp/build/tensorrt_llm:${tensorrt-llm}/cpp/build/tensorrt_llm/plugins:${cudnn}/lib --replace-needed libtritonserver.so libtritonserver-90a4cf82.so --add-needed libcudnn.so.8
+    patchelf $out/backends/tensorrtllm/libtriton_tensorrtllm.so \
+      --add-rpath ${trt_lib_dir}:${tensorrt-llm}/cpp/build/tensorrt_llm:${tensorrt-llm}/cpp/build/tensorrt_llm/plugins:${cudnn}/lib \
+      --add-needed libcudnn.so.8
   '';
 }

--- a/nix/trtllm-backend.nix
+++ b/nix/trtllm-backend.nix
@@ -45,8 +45,6 @@ let
   trt_lib_dir = "${pythonDrvs.tensorrt-libs.public}/${sitePackages}/tensorrt_libs";
   # this package wants gcc12
   oldGccStdenv = stdenvAdapters.useLibsFrom stdenv gcc12Stdenv;
-  # todo don't mix this and cudaPkgs.cudnn:
-  cudnn = "${pythonDrvs.nvidia-cudnn-cu12.public}/${sitePackages}/nvidia/cudnn";
 in
 oldGccStdenv.mkDerivation rec {
   pname = "tensorrtllm_backend";
@@ -85,10 +83,8 @@ oldGccStdenv.mkDerivation rec {
     "-DCUDAToolkit_INCLUDE_DIR=${cudaPackages.cuda_cudart}/include"
   ];
   # buildInputs = [ tensorrt-llm ];
-  # todo I think tensorrt_llm.so itself should have the cudnn dep
   postFixup = ''
     patchelf $out/backends/tensorrtllm/libtriton_tensorrtllm.so \
-      --add-rpath ${trt_lib_dir}:${tensorrt-llm}/cpp/build/tensorrt_llm:${tensorrt-llm}/cpp/build/tensorrt_llm/plugins:${cudnn}/lib \
-      --add-needed libcudnn.so.8
+      --add-rpath ${trt_lib_dir}:${tensorrt-llm}/cpp/build/tensorrt_llm:${tensorrt-llm}/cpp/build/tensorrt_llm/plugins
   '';
 }


### PR DESCRIPTION
- These are actually the same redistributables, so just symlink them. Saves a bunch of space. The images are now 5.4GB.
- Remove a bunch of cuda kernel source files.
- Also fix that annoying `libtritonserver-90a4cf82.so` patch.

Tested and working.
Pushed to cache:
- [x] runner-86
- [x] runner-80
- [x] runner-90
- [x] builder