### PR TITLE
Backport some changes from trtllm-0.9 branch

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -48,11 +48,11 @@ jobs:
         ./cog-triton-builder push r8.im/replicate-internal/cog-triton-ci
         echo "::endgroup::"
         echo "::group::Runner-80"
-        ./cog-triton-runner-80 push r8.im/replicate-internal/cog-triton-ci
+        ./cog-triton-runner-80 push r8.im/replicate-internal/triton-base-sm80
         echo "::endgroup::"
         echo "::group::Runner-86"
         ./cog-triton-runner-86 push r8.im/replicate-internal/cog-triton-ci
         echo "::endgroup::"
         echo "::group::Runner-90"
-        ./cog-triton-runner-90 push r8.im/replicate-internal/cog-triton-ci
+        ./cog-triton-runner-90 push r8.im/replicate-internal/triton-base-sm90
         echo "::endgroup::"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-16-cores
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -18,11 +18,12 @@ jobs:
         workload_identity_provider: projects/752785843927/locations/global/workloadIdentityPools/github/providers/github-actions-workload-prvdr
         service_account: github-actions-service-account@yorick-dev-416917.iam.gserviceaccount.com
     - name: Set up cache
-      uses: zombiezen/setup-nix-cache-action@v0.3.2
+      uses: zombiezen/setup-nix-cache-action@v0.4.0
       with:
         substituters: gs://replicate-nix-cache-dev
         secret_keys: ${{ secrets.NIX_PRIVATE_KEY }}
         use_nixcached: true
+        nixcached_upload_options: -j12
     - name: Get ssh key from secret
       env:
         GIT_SSH_KEY: ${{ secrets.GIT_SSH_KEY }}
@@ -30,16 +31,28 @@ jobs:
         mkdir -p ~/.ssh
         cat > ~/.ssh/id_ed25519 <<< "$GIT_SSH_KEY"
         chmod 0600 ~/.ssh/id_ed25519
-    - run: nix build --accept-flake-config .#cog-triton-builder -o cog-triton-builder
-    - run: nix build --accept-flake-config .#cog-triton-runner-86 -o cog-triton-runner-86
-    - run: nix build --accept-flake-config .#cog-triton-runner-80 -o cog-triton-runner-80
-    - run: nix build --accept-flake-config .#cog-triton-runner-90 -o cog-triton-runner-90
+    - name: Build cog-triton-builder
+      run: nix build --accept-flake-config .#cog-triton-builder -o cog-triton-builder
+    - name: Build cog-triton-runner-80
+      run: nix build --accept-flake-config .#cog-triton-runner-80 -o cog-triton-runner-80
+    - name: Build cog-triton-runner-86
+      run: nix build --accept-flake-config .#cog-triton-runner-86 -o cog-triton-runner-86
+    - name: Build cog-triton-runner-90
+      run: nix build --accept-flake-config .#cog-triton-runner-90 -o cog-triton-runner-90
     - run: nix path-info --closure-size --human-readable ./cog-triton-*
     - name: Push to replicate
       env:
         COG_TOKEN: ${{ secrets.COG_TOKEN }}
       run: |
+        echo "::group::Builder"
         ./cog-triton-builder push r8.im/replicate-internal/cog-triton-ci
-        ./cog-triton-runner-86 push r8.im/replicate-internal/cog-triton-ci
+        echo "::endgroup::"
+        echo "::group::Runner-80"
         ./cog-triton-runner-80 push r8.im/replicate-internal/cog-triton-ci
+        echo "::endgroup::"
+        echo "::group::Runner-86"
+        ./cog-triton-runner-86 push r8.im/replicate-internal/cog-triton-ci
+        echo "::endgroup::"
+        echo "::group::Runner-90"
         ./cog-triton-runner-90 push r8.im/replicate-internal/cog-triton-ci
+        echo "::endgroup::"

--- a/flake.nix
+++ b/flake.nix
@@ -17,15 +17,15 @@
           Labels."org.opencontainers.image.revision" = sourceRev;
         };
       }) "${self}";
-      makeRunner = name: architectures: env: callCognix {
+      makeRunner = name: architectures: env: callCognix ( {config, lib, ... }: {
         inherit name;
         cog-triton = {
           inherit architectures;
           # only grab deps of nvidia-pytriton, transformers
           rootDependencies = [ "nvidia-pytriton" "transformers" ];
         };
-        cognix.environment = env;
-      };
+        cognix.environment.TRITONSERVER_BACKEND_DIR = "${config.deps.backend_dir}/backends";
+      });
       makeBuilder = name: callCognix ( { config, lib, ... }: {
         inherit name;
         cog-triton = {

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,10 @@
           rootDependencies = [ "nvidia-pytriton" "transformers" ];
         };
         cognix.environment.TRITONSERVER_BACKEND_DIR = "${config.deps.backend_dir}/backends";
+        # don't need this file in a runner
+        python-env.pip.drvs.tensorrt-libs.mkDerivation.postInstall = lib.mkAfter ''
+          rm $out/lib/python*/site-packages/tensorrt_libs/libnvinfer_builder_resource*
+        '';
       });
       makeBuilder = name: callCognix ( { config, lib, ... }: {
         inherit name;

--- a/nix/tensorrt-llm.nix
+++ b/nix/tensorrt-llm.nix
@@ -133,7 +133,7 @@ stdenv.mkDerivation (o: {
       mkdir -p $out/cpp/build/tensorrt_llm/plugins
       pushd tensorrt_llm
       cp ./libtensorrt_llm.so $out/cpp/build/tensorrt_llm/
-      patchelf --add-needed 'libcudnn.so.8' $out/cpp/build/tensorrt_llm/libtensorrt_llm.so
+      patchelf --add-needed 'libcudnn.so.8' --add-rpath ${cudaPackages.cudnn.lib}/lib $out/cpp/build/tensorrt_llm/libtensorrt_llm.so
       cp ./plugins/libnvinfer_plugin_tensorrt_llm.so* $out/cpp/build/tensorrt_llm/plugins/
       for f in $out/cpp/build/tensorrt_llm/plugins/*.so*; do
         if [ ! -L "$f" ]; then

--- a/predict.py
+++ b/predict.py
@@ -13,6 +13,7 @@ from triton_config_generator import generate_configs, load_yaml_config
 import pytriton.utils.distribution
 
 TRITONSERVER_DIST_DIR = pytriton.utils.distribution.get_root_module_path() / "tritonserver"
+TRITONSERVER_BACKEND_DIR = os.getenv("TRITONSERVER_BACKEND_DIR", str(TRITONSERVER_DIST_DIR / "backends"))
 
 import numpy as np
 
@@ -94,7 +95,7 @@ class Predictor(BasePredictor):
             cmd += [
                 "-n", "1",
                 str(TRITONSERVER_DIST_DIR / "bin" / "tritonserver"),
-                "--backend-dir", str(TRITONSERVER_DIST_DIR / "backends"),
+                "--backend-dir", TRITONSERVER_BACKEND_DIR,
                 #"--log-verbose=3", "--log-file=triton_log.txt",
                 "--model-repository", "/src/triton_model_repo",
                 f"--backend-config=python,shm-region-prefix-name=prefix{i}_"


### PR DESCRIPTION
#33 contains some changes that make life better and has some further size optimizations.

- pushes to triton-base-sm80, triton-base-sm90
- remove libnvinfer_builder_resource.so from runners
- double the GHA cores
- put backends in a separate package, so we can share the `nvidia-pytriton` package across builds
