### PR TITLE
Update nix CI so that runner-86 is pushed to it's 

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -51,7 +51,7 @@ jobs:
         ./cog-triton-runner-80 push r8.im/replicate-internal/triton-base-sm80
         echo "::endgroup::"
         echo "::group::Runner-86"
-        ./cog-triton-runner-86 push r8.im/replicate-internal/cog-triton-ci
+        ./cog-triton-runner-86 push r8.im/replicate-internal/triton-base-sm86
         echo "::endgroup::"
         echo "::group::Runner-90"
         ./cog-triton-runner-90 push r8.im/replicate-internal/triton-base-sm90


### PR DESCRIPTION
This PR updates the nix CI workflow so that the runner-86 image is pushed to a distinct and appropriate Replicate model.

Currently, CI pushes runner-80 and runner-90 to their own `triton-base-sm{xx}` Replicate model, which makes it easy ensure selecting a runner that's compatible with target hardware. However, runner-86 is pushed to cog-triton-ci, which is where the builder is pushed.