### PR TITLE
handle triton 0.10.0 not returning the entire sequence

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -269,7 +269,6 @@ class Predictor(BasePredictor):
         )
 
         output = ""
-        generation_length = 0
         stop_sequence_handler = StreamingTokenStopSequenceHandler(
             stop_sequences=args["stop_words"]
         )
@@ -281,7 +280,7 @@ class Predictor(BasePredictor):
 
         async with req as resp:
             async for event in receive_sse(resp):
-                # Output is the _entire_ sequence, from the beginning
+                # Output may be the _entire_ sequence, from the beginning
                 try:
                     token = event.json()["output_ids"]
                 # this check can be removed once we identify the cause of KeyError
@@ -293,11 +292,11 @@ class Predictor(BasePredictor):
                     first_token_time = time.time()
 
                 tokens = np.append(tokens, token)
-                output = self.tokenizer.decode(tokens, skip_special_tokens=True)
+                new_output = self.tokenizer.decode(tokens, skip_special_tokens=True)
                 # Catches partial emojis, waits for them to finish
-                output = output.replace("\N{REPLACEMENT CHARACTER}", "")
+                new_output = new_output.replace("\N{REPLACEMENT CHARACTER}", "")
                 # Remove the tokens that were already yielded
-                current_output = output[generation_length:]
+                current_output = new_output.removeprefix(output)
 
                 if current_output:
                     # Process the output for stop sequences
@@ -307,8 +306,8 @@ class Predictor(BasePredictor):
                     if current_output:
                         yield current_output
 
-                # Update generation length
-                generation_length = len(output)
+                # Update output
+                output = new_output
 
             # Handles the case where the generation ends in the middle of a valid stop sequence
             current_output = stop_sequence_handler.finalize()


### PR DESCRIPTION
triton 0.10.0 has a breaking change. this PR tries to support it.

<a href="https://github.com/NVIDIA/TensorRT-LLM/releases/tag/v0.10.0#:~:text=The%20input%20prompt%20was%20removed%20from%20the%20generation%20output">https://github.com/NVIDIA/TensorRT-LLM/releases/tag/v0.10.0#:~:text=The%20input%20prompt%20was%20removed%20from%20the%20generation%20output</a>