### PR TITLE
better errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,25 @@ A cog implementation of Nvidia's Triton server
 
 ## Error codes
 
-E000: Unknown error
+Universal user errors:
+
+E000: Generic user error (not used)
 E001: A prompt is required, but your formatted prompt is blank
-E002: Can't set both max_tokens ({max_tokens}) and max_new_tokens ({max_new_tokens})
-E003: Can't set both min_tokens ({min_tokens}) and min_new_tokens ({min_new_tokens})
-E004: Prompt length exceeds maximum input length.
-E005: Tokenizer error: ... the first token of the stop sequence IDs was not '!', which suggests there is a problem with the tokenizer that you are using.
-E006: Triton returned malformed event (no output_ids or error key)
-E007: Triton timed out after 120s: httpx.ReadTimeout.
-E008: You have submitted both a prompt and a prompt template that doesn't include '{prompt}'.
-E009: Triton returned malformed JSON
+E002: Prompt length exceeds maximum input length.
+E003: You have submitted both a prompt and a prompt template that doesn't include '{prompt}'.
+
+Triton user errors:
+
+E101: Can't set both max_tokens ({max_tokens}) and max_new_tokens ({max_new_tokens})
+E102: Can't set both min_tokens ({min_tokens}) and min_new_tokens ({min_new_tokens})
+
+Triton errors:
+
+E200: Unknown error
+E201: Triton timed out after 120s: httpx.ReadTimeout.
+E202: Tokenizer error: ... the first token of the stop sequence IDs was not '!', which suggests there is a problem with the tokenizer that you are using.
+E203: Triton returned malformed JSON
+E204: Triton returned malformed event (no output_ids or error key)
 
 ## Create a Replicate Model with cog-triton
 

--- a/README.md
+++ b/README.md
@@ -3,25 +3,35 @@ A cog implementation of Nvidia's Triton server
 
 ## Error codes
 
-Universal user errors:
+We are using "E[Category][Subcategory][Sequence] [Short Error Name]: [Description]
 
-E000: Generic user error (not used)
-E001: A prompt is required, but your formatted prompt is blank
-E002: Prompt length exceeds maximum input length.
-E003: You have submitted both a prompt and a prompt template that doesn't include '{prompt}'.
+### Universal user errors:
 
-Triton user errors:
+Category 1 (user error), subcategory 0 (framework-agnostic user errors).
 
-E101: Can't set both max_tokens ({max_tokens}) and max_new_tokens ({max_new_tokens})
-E102: Can't set both min_tokens ({min_tokens}) and min_new_tokens ({min_new_tokens})
+* E1000 GenericError: Generic user error (reserved)
+* E1001 PromptRequired: A prompt is required, but your formatted prompt is blank
+* E1002 PromptTooLong: Prompt length exceeds maximum input length.
+* E1003 BadPromptTemplate: You have submitted both a prompt and a prompt template that doesn't include '{prompt}'.
 
-Triton errors:
+### Triton user errors:
 
-E200: Unknown error
-E201: Triton timed out after 120s: httpx.ReadTimeout.
-E202: Tokenizer error: ... the first token of the stop sequence IDs was not '!', which suggests there is a problem with the tokenizer that you are using.
-E203: Triton returned malformed JSON
-E204: Triton returned malformed event (no output_ids or error key)
+Category 1 (user error), subcategory 1 (triton-specific user errors)
+
+* E1101 InvalidArgumentMinTokens: Can't set both min_tokens ({min_tokens}) and min_new_tokens ({min_new_tokens})
+* E1102 InvalidArgumentMaxTokens: Can't set both max_tokens ({max_tokens}) and max_new_tokens ({max_new_tokens})
+
+### Triton errors:
+
+Category 2 (framework error), subcategory 1 (triton system error)
+
+* E2100 TritonUnknownError: Unknown error
+* E2101 TritonTimeout: Triton timed out after {TRITON_TIMEOUT}s: httpx.ReadTimeout.
+* E2102 TritonTokenizerError: Tokenizer error: ... the first token of the stop sequence IDs was not '!', which suggests there is a problem with the tokenizer that you are using.
+* E2103 TritonMalformedJSON: Triton returned malformed JSON
+* E2104 TritonMalformedEvent: Triton returned malformed event (no output_ids or error key)
+
+Other frameworks like vLLM might start their error numbering from E2200. 
 
 ## Create a Replicate Model with cog-triton
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # cog-triton
 A cog implementation of Nvidia's Triton server
 
+## Error codes
+
+E000: Unknown error
+E001: A prompt is required, but your formatted prompt is blank
+E002: Can't set both max_tokens ({max_tokens}) and max_new_tokens ({max_new_tokens})
+E003: Can't set both min_tokens ({min_tokens}) and min_new_tokens ({min_new_tokens})
+E004: Prompt length exceeds maximum input length.
+E005: Tokenizer error: ... the first token of the stop sequence IDs was not '!', which suggests there is a problem with the tokenizer that you are using.
+E006: Triton returned malformed event (no output_ids or error key)
+E007: Triton timed out after 120s: httpx.ReadTimeout.
+E008: You have submitted both a prompt and a prompt template that doesn't include '{prompt}'.
+E009: Triton returned malformed JSON
+
 ## Create a Replicate Model with cog-triton
 
 Currently, we use [yolo](https://github.com/replicate/yolo), a CLI tool we've built to help with non-standard Replicate workflows. To get started, install yolo:

--- a/triton_model_repo/preprocessing/1/model.py
+++ b/triton_model_repo/preprocessing/1/model.py
@@ -285,9 +285,9 @@ class TritonPythonModel:
                 ids = self.tokenizer.encode(word, add_special_tokens=False)
                 if ids[0] != arbitrary_start_sequence_id:
                     raise ValueError(
-                        f"To standardize tokenizer behavior, we prepend '{arbitrary_start_sequence_token}' to the string representation of each stop sequence."
-                        "We then strip the corresponding first token from the stop sequence IDs."
-                        "However, the first token of the stop sequence IDs was not '{arbitrary_start_sequence_id}', which suggestions there is a problem with the tokenizer that you are using."
+                        f"To standardize tokenizer behavior, we prepend '{arbitrary_start_sequence_token}' to the string representation of each stop sequence. "
+                        "We then strip the corresponding first token from the stop sequence IDs. "
+                        "However, the first token of the stop sequence IDs was not '{arbitrary_start_sequence_id}', which suggests there is a problem with the tokenizer that you are using."
                     )
                 else:
                     ids = ids[1:]


### PR DESCRIPTION
better error formatting in general (grab the 'error' key if present) and also hierarchical error codes for splitting out user errors, framework-specific user errors, and system errors. this also adds a message to the ReadTimeout