### PR TITLE
reuse downloaded weights

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -10,7 +10,7 @@ import requests
 
 def maybe_download_tarball_with_pget(
     url: str,
-    dest: str,
+    real_dest: str,
 ):
     """
     Downloads a tarball from url and decompresses to dest if dest does not exist. Remote path is constructed
@@ -25,9 +25,13 @@ def maybe_download_tarball_with_pget(
 
     """
 
+    Path("/weights").mkdir(exit_ok=True)
+    dest = "/weights/triton"
+
     # if dest exists and is not empty, return
     if os.path.exists(dest) and os.listdir(dest):
         print(f"Files already present in the `{dest}`, nothing will be downloaded.")
+        os.symlink(dest, real_dest)
         return dest
 
     # if dest exists but is empty, remove it so we can pull with pget
@@ -37,6 +41,7 @@ def maybe_download_tarball_with_pget(
     print("Downloading model assets...")
     command = ["pget", url, dest, "-x"]
     subprocess.check_call(command, close_fds=True)
+    os.symlink(dest, real_dest)
 
     return dest
 

--- a/utils.py
+++ b/utils.py
@@ -24,14 +24,19 @@ def maybe_download_tarball_with_pget(
         path (str): Path to the directory where files were downloaded
 
     """
+    try:
+        Path("/weights").mkdir(exit_ok=True)
+        dest = "/weights/triton"
+    except PermissionError:
+        print("/weights doesn't exist, and we couldn't create it")
+        dest = real_dest
 
-    Path("/weights").mkdir(exit_ok=True)
-    dest = "/weights/triton"
 
     # if dest exists and is not empty, return
     if os.path.exists(dest) and os.listdir(dest):
-        print(f"Files already present in the `{dest}`, nothing will be downloaded.")
-        os.symlink(dest, real_dest)
+        print(f"Files already present in `{dest}`, nothing will be downloaded.")
+        if dest != real_dest:
+            os.symlink(dest, real_dest)
         return dest
 
     # if dest exists but is empty, remove it so we can pull with pget
@@ -41,7 +46,8 @@ def maybe_download_tarball_with_pget(
     print("Downloading model assets...")
     command = ["pget", url, dest, "-x"]
     subprocess.check_call(command, close_fds=True)
-    os.symlink(dest, real_dest)
+    if dest != real_dest:
+        os.symlink(dest, real_dest)
 
     return dest
 


### PR DESCRIPTION
we should be careful to make this work even if /weights in not mounted, verify that triton works with symlinks (should be fine), that pget won't throw an error, and that it doesn't break locally. if we're not root, trying to create /weights will fail, and maybe we should handle that as well.
